### PR TITLE
Fixed bug with arrays

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -237,7 +237,11 @@ const evaluateFns: { [type: string]: EvaluateFunction<any> } = {
         throw new Error(`Cannot call ${node.object.type}`);
       default:
         const object = evaluate(node.object, scope);
-        return evaluate(node.property, object);
+        if (node.computed) {
+          return object[evaluate(node.property, scope)];
+        } else {
+          return evaluate(node.property, object);
+        }
     }
   },
 


### PR DESCRIPTION
I'm using the latest version of acorn and found there was an issue when evaluating arrays.

